### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pkgVersion.yml
+++ b/.github/workflows/pkgVersion.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   check:
     name: Check npm packages version
+    permissions:
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/luthpg/gasnuki/security/code-scanning/3](https://github.com/luthpg/gasnuki/security/code-scanning/3)

To fix the problem, you should add a `permissions` block to the workflow or the specific job(s) that require it. The block should grant only the minimum permissions necessary for the workflow to function. In this case, most steps only require `contents: read`, but the step that creates a GitHub issue (`peter-evans/create-issue-from-file@v4`) requires `issues: write`. The best practice is to add the `permissions` block at the job level for the `check` job, specifying `contents: read` and `issues: write`. This change should be made directly under the `check` job definition (after `name:` and before `runs-on:`) in `.github/workflows/pkgVersion.yml`. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
