### PR TITLE
pnpm-lock.yamlの依存関係を更新し、READMEファイルのテストカバレッジバッジを79.67%に変更。型定義ファイルのインター…

### DIFF
--- a/.bin/typedef/clientside.d.ts
+++ b/.bin/typedef/clientside.d.ts
@@ -21,7 +21,7 @@ type _AppsScriptHistoryFunction = (
   hash: string,
 ) => void;
 
-interface _WebAppLovacationType {
+interface _WebAppLocationType {
   hash: string;
   parameter: Record<string, string>;
   parameters: Record<string, string[]>;
@@ -31,9 +31,7 @@ export declare interface GoogleClientSideApi {
   script: {
     run: _AppsScriptRun;
     url: {
-      getLocation: (
-        callback: (location: _WebAppLovacationType) => void,
-      ) => void;
+      getLocation: (callback: (location: _WebAppLocationType) => void) => void;
     };
     history: {
       push: _AppsScriptHistoryFunction;
@@ -41,7 +39,7 @@ export declare interface GoogleClientSideApi {
       setChangeHandler: (
         callback: (e: {
           state: object;
-          location: _WebAppLovacationType;
+          location: _WebAppLocationType;
         }) => void,
       ) => void;
     };

--- a/.github/workflows/pkgVersion.yml
+++ b/.github/workflows/pkgVersion.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.x
+          version: 10.11.1
     
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,6 +1,6 @@
 # gasnuki
 
-[![Test Coverage](https://img.shields.io/badge/test%20coverage-77.03%25-yellowgreen)](https://github.com/luthpg/gasnuki)
+[![Test Coverage](https://img.shields.io/badge/test%20coverage-79.67%25-yellowgreen)](https://github.com/luthpg/gasnuki)
 [![License](https://img.shields.io/badge/license-ISC-blue.svg)](LICENSE)
 [![npm version](https://img.shields.io/npm/v/@ciderjs/gasnuki.svg)](https://www.npmjs.com/package/@ciderjs/gasnuki)
 [![GitHub issues](https://img.shields.io/github/issues/luthpg/gasnuki.svg)](https://github.com/luthpg/gasnuki/issues)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @ciderjs/gasnuki
 
-[![Test Coverage](https://img.shields.io/badge/test%20coverage-77.03%25-yellowgreen)](https://github.com/luthpg/gasnuki)
+[![Test Coverage](https://img.shields.io/badge/test%20coverage-79.67%25-yellowgreen)](https://github.com/luthpg/gasnuki)
 [![License](https://img.shields.io/badge/license-ISC-blue.svg)](LICENSE)
 [![npm version](https://img.shields.io/npm/v/@ciderjs/gasnuki.svg)](https://www.npmjs.com/package/@ciderjs/gasnuki)
 [![GitHub issues](https://img.shields.io/github/issues/luthpg/gasnuki.svg)](https://github.com/luthpg/gasnuki/issues)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,10 @@ importers:
         version: 22.15.29
       '@vitest/coverage-v8':
         specifier: 3.2.1
-        version: 3.2.1(vitest@3.2.1(@types/node@22.15.29)(jiti@2.4.2)(terser@5.43.1))
+        version: 3.2.1(vitest@3.2.1)
+      '@vitest/ui':
+        specifier: 3.2.1
+        version: 3.2.1(vitest@3.2.1)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -41,7 +44,7 @@ importers:
         version: 3.5.0(typescript@5.8.3)(vue-tsc@2.2.12(typescript@5.8.3))(vue@3.5.17(typescript@5.8.3))
       vitest:
         specifier: ^3.2.1
-        version: 3.2.1(@types/node@22.15.29)(jiti@2.4.2)(terser@5.43.1)
+        version: 3.2.1(@types/node@22.15.29)(@vitest/ui@3.2.1)(jiti@2.4.2)(terser@5.43.1)
 
   playground/react:
     dependencies:
@@ -737,6 +740,9 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
   '@rolldown/binding-android-arm64@1.0.0-beta.29':
     resolution: {integrity: sha512-pDv7gg59Gdy80eFmMkEqXEaoJi3Y9W/a9T3z9M4t8Ma8aVXNldvSy9UgtlX7AK7DPqF8tULnmIZ2Z3rvGMz/NQ==}
     cpu: [arm64]
@@ -1302,6 +1308,11 @@ packages:
 
   '@vitest/spy@3.2.1':
     resolution: {integrity: sha512-Nbfib34Z2rfcJGSetMxjDCznn4pCYPZOtQYox2kzebIJcgH75yheIKd5QYSFmR8DIZf2M8fwOm66qSDIfRFFfQ==}
+
+  '@vitest/ui@3.2.1':
+    resolution: {integrity: sha512-xT93aOcPn2wn8vvw4T6rZAK9WjGEHdYrEjN3OJ1zcDpl2UInxvcD9fYI10nmPAERNEK6jUVcSCIPAIfNuaRX6Q==}
+    peerDependencies:
+      vitest: 3.2.1
 
   '@vitest/utils@3.2.1':
     resolution: {integrity: sha512-KkHlGhePEKZSub5ViknBcN5KEF+u7dSUr9NW8QsVICusUojrgrOnnY3DEWWO877ax2Pyopuk2qHmt+gkNKnBVw==}
@@ -2081,6 +2092,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
@@ -2785,6 +2799,10 @@ packages:
   mlly@1.7.4:
     resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
 
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
@@ -3449,6 +3467,10 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  sirv@3.0.1:
+    resolution: {integrity: sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==}
+    engines: {node: '>=18'}
+
   slice-ansi@5.0.0:
     resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
     engines: {node: '>=12'}
@@ -3637,6 +3659,10 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
@@ -4548,6 +4574,8 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@polka/url@1.0.0-next.29': {}
+
   '@rolldown/binding-android-arm64@1.0.0-beta.29':
     optional: true
 
@@ -4987,7 +5015,7 @@ snapshots:
       vite: 6.3.5(@types/node@22.15.29)(jiti@2.4.2)(terser@5.43.1)
       vue: 3.5.17(typescript@5.8.3)
 
-  '@vitest/coverage-v8@3.2.1(vitest@3.2.1(@types/node@22.15.29)(jiti@2.4.2)(terser@5.43.1))':
+  '@vitest/coverage-v8@3.2.1(vitest@3.2.1)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -5002,7 +5030,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.1(@types/node@22.15.29)(jiti@2.4.2)(terser@5.43.1)
+      vitest: 3.2.1(@types/node@22.15.29)(@vitest/ui@3.2.1)(jiti@2.4.2)(terser@5.43.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5040,6 +5068,17 @@ snapshots:
   '@vitest/spy@3.2.1':
     dependencies:
       tinyspy: 4.0.3
+
+  '@vitest/ui@3.2.1(vitest@3.2.1)':
+    dependencies:
+      '@vitest/utils': 3.2.1
+      fflate: 0.8.2
+      flatted: 3.3.3
+      pathe: 2.0.3
+      sirv: 3.0.1
+      tinyglobby: 0.2.14
+      tinyrainbow: 2.0.0
+      vitest: 3.2.1(@types/node@22.15.29)(@vitest/ui@3.2.1)(jiti@2.4.2)(terser@5.43.1)
 
   '@vitest/utils@3.2.1':
     dependencies:
@@ -5926,6 +5965,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fflate@0.8.2: {}
+
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -6648,6 +6689,8 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.1
+
+  mrmime@2.0.1: {}
 
   ms@2.0.0: {}
 
@@ -7375,6 +7418,12 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  sirv@3.0.1:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   slice-ansi@5.0.0:
     dependencies:
       ansi-styles: 6.2.1
@@ -7538,8 +7587,8 @@ snapshots:
 
   tinyglobby@0.2.14:
     dependencies:
-      fdir: 6.4.5(picomatch@4.0.2)
-      picomatch: 4.0.2
+      fdir: 6.4.6(picomatch@4.0.3)
+      picomatch: 4.0.3
 
   tinypool@1.1.0: {}
 
@@ -7572,6 +7621,8 @@ snapshots:
       safe-regex: 1.1.0
 
   toidentifier@1.0.1: {}
+
+  totalist@3.0.1: {}
 
   tr46@0.0.3: {}
 
@@ -7774,7 +7825,7 @@ snapshots:
       jiti: 2.4.2
       terser: 5.43.1
 
-  vitest@3.2.1(@types/node@22.15.29)(jiti@2.4.2)(terser@5.43.1):
+  vitest@3.2.1(@types/node@22.15.29)(@vitest/ui@3.2.1)(jiti@2.4.2)(terser@5.43.1):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.1
@@ -7801,6 +7852,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.15.29
+      '@vitest/ui': 3.2.1(vitest@3.2.1)
     transitivePeerDependencies:
       - jiti
       - less

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -7,18 +7,18 @@ vi.mock('commander', () => ({
     opts: vi.fn(() => ({
       project: '/p',
       watch: false,
-      srcDir: 'src',
-      outDir: 'out',
-      outputFile: 'types.ts',
+      srcDir: 'server',
+      outDir: 'types',
+      outputFile: 'appsscript.ts',
     })),
     options: [
       { attributeName: () => 'project', defaultValue: '/p' },
       { attributeName: () => 'watch', defaultValue: false },
-      { attributeName: () => 'srcDir', defaultValue: 'src' },
-      { attributeName: () => 'outDir', defaultValue: 'out' },
-      { attributeName: () => 'outputFile', defaultValue: 'types.ts' },
+      { attributeName: () => 'srcDir', defaultValue: 'server' },
+      { attributeName: () => 'outDir', defaultValue: 'types' },
+      { attributeName: () => 'outputFile', defaultValue: 'appsscript.ts' },
     ],
-    getOptionValueSource: vi.fn(() => 'cli'),
+    getOptionValueSource: vi.fn(() => 'default'),
     parseAsync: vi.fn(),
     name: vi.fn().mockReturnThis(),
     description: vi.fn().mockReturnThis(),
@@ -48,10 +48,146 @@ describe('parseArgs', () => {
     expect(callArg.project).toBe('/p');
     expect(callArg.watch).toBe(false);
   });
+
+  it('ファイル設定がCLIオプションより優先される', async () => {
+    const { Command } = await import('commander');
+    const { loadConfig } = await import('../src/modules/config');
+    const { generateTypes } = await import('../src/index');
+
+    // ファイル設定をモック
+    (loadConfig as any).mockResolvedValue({
+      srcDir: 'custom-src',
+      outDir: 'custom-out',
+      outputFile: 'custom.ts',
+    });
+
+    const command = new Command();
+    command.getOptionValueSource = vi.fn(() => 'default');
+    await parseArgs(command);
+
+    const callArg = (generateTypes as any).mock.calls[0][0];
+    expect(callArg.srcDir).toBe('custom-src');
+    expect(callArg.outDir).toBe('custom-out');
+    expect(callArg.outputFile).toBe('custom.ts');
+  });
+
+  it('明示的なCLIオプションがファイル設定より優先される', async () => {
+    const { Command } = await import('commander');
+    const { loadConfig } = await import('../src/modules/config');
+    const { generateTypes } = await import('../src/index');
+
+    // ファイル設定をモック
+    (loadConfig as any).mockResolvedValue({
+      srcDir: 'file-src',
+      outDir: 'file-out',
+    });
+
+    // CLIオプションの値を明示的に設定
+    const command = new Command();
+    command.getOptionValueSource = vi.fn((key: string) => {
+      if (key === 'srcDir') return 'cli';
+      return 'default';
+    });
+    // CLIオプションの値を明示的に設定
+    (command.opts as any) = vi.fn(() => ({
+      project: '/p',
+      watch: false,
+      srcDir: 'cli-src', // CLIで明示的に設定された値
+      outDir: 'out',
+      outputFile: 'types.ts',
+    }));
+
+    await parseArgs(command);
+
+    const callArg = (generateTypes as any).mock.calls[0][0];
+    expect(callArg.srcDir).toBe('cli-src'); // CLIオプションが優先
+    expect(callArg.outDir).toBe('file-out'); // ファイル設定が使用
+  });
+
+  it('デフォルト値が正しく設定される', async () => {
+    const { Command } = await import('commander');
+    const { loadConfig } = await import('../src/modules/config');
+    const { generateTypes } = await import('../src/index');
+
+    // loadConfigを空のオブジェクトを返すように明示的にリセット
+    (loadConfig as any).mockResolvedValue({});
+
+    const command = new Command();
+    command.getOptionValueSource = vi.fn(() => 'default');
+
+    await parseArgs(command);
+
+    const callArg = (generateTypes as any).mock.calls[0][0];
+    console.dir(callArg);
+    expect(callArg.srcDir).toBe('server');
+    expect(callArg.outDir).toBe('types');
+    expect(callArg.outputFile).toBe('appsscript.ts');
+    expect(callArg.watch).toBe(false);
+  });
+
+  it('watchオプションが正しく処理される', async () => {
+    const { Command } = await import('commander');
+    const { generateTypes } = await import('../src/index');
+
+    const command = new Command();
+    (command.opts as any) = vi.fn(() => ({
+      project: '/p',
+      watch: true,
+      srcDir: 'server',
+      outDir: 'types',
+      outputFile: 'appsscript.ts',
+    }));
+
+    await parseArgs(command);
+
+    const callArg = (generateTypes as any).mock.calls[0][0];
+    expect(callArg.watch).toBe(true);
+  });
+
+  it('プロジェクトパスが正しく設定される', async () => {
+    const { Command } = await import('commander');
+    const { generateTypes } = await import('../src/index');
+
+    const command = new Command();
+    (command.opts as any) = vi.fn(() => ({
+      project: '/custom/project',
+      watch: false,
+      srcDir: 'server',
+      outDir: 'types',
+      outputFile: 'appsscript.ts',
+    }));
+
+    await parseArgs(command);
+
+    const callArg = (generateTypes as any).mock.calls[0][0];
+    expect(callArg.project).toBe('/custom/project');
+  });
+
+  it('generateTypesでエラーが発生した場合に適切に処理される', async () => {
+    const { Command } = await import('commander');
+    const { generateTypes } = await import('../src/index');
+
+    // generateTypesでエラーを投げる
+    (generateTypes as any).mockRejectedValue(new Error('Generation failed'));
+
+    const command = new Command();
+
+    await expect(parseArgs(command)).rejects.toThrow('Generation failed');
+  });
 });
 
 describe('cli', () => {
   it('CLIエントリポイントがエラーなく動作する', async () => {
     await expect(cli()).resolves.not.toThrow();
+  });
+
+  // CLIの詳細なテストは複雑なモックが必要なため、基本的な動作のみをテスト
+  it('CLIが正常に実行される', async () => {
+    const { Command } = await import('commander');
+
+    await cli();
+
+    // Commandが作成されることを確認
+    expect(Command).toHaveBeenCalled();
   });
 });

--- a/tests/modules/config.test.ts
+++ b/tests/modules/config.test.ts
@@ -20,6 +20,22 @@ describe('defineConfig', () => {
     expect(config.outDir).toBe('types');
     expect(config.srcDir).toBe('src');
   });
+
+  it('空の設定オブジェクトを返す', () => {
+    const config = defineConfig({});
+    expect(config).toEqual({});
+  });
+
+  it('全ての設定オプションを含む設定を返す', () => {
+    const config = defineConfig({
+      srcDir: 'custom-src',
+      outDir: 'custom-out',
+      outputFile: 'custom.ts',
+    });
+    expect(config.srcDir).toBe('custom-src');
+    expect(config.outDir).toBe('custom-out');
+    expect(config.outputFile).toBe('custom.ts');
+  });
 });
 
 describe('loadConfig', () => {
@@ -50,5 +66,132 @@ describe('loadConfig', () => {
     (createJiti as any).mockReturnValue({ import: importMock });
     const config = await loadConfig('/project');
     expect(config).toEqual({});
+  });
+
+  it('複数の設定ファイル拡張子を順番にチェックする', async () => {
+    const { existsSync } = await import('node:fs');
+    const { createJiti } = await import('jiti');
+    const { consola } = await import('consola');
+
+    // 最初の拡張子では存在せず、2番目の拡張子で存在する
+    (existsSync as any)
+      .mockReturnValueOnce(false) // .ts
+      .mockReturnValueOnce(true); // .mts
+
+    const importMock = vi.fn(() => Promise.resolve({ srcDir: 'custom-src' }));
+    (createJiti as any).mockReturnValue({ import: importMock });
+
+    const config = await loadConfig('/project');
+
+    expect(config).toEqual({ srcDir: 'custom-src' });
+    expect(consola.success).toHaveBeenCalledWith(
+      'Loaded configuration from gasnuki.config.mts',
+    );
+  });
+
+  it('最初に見つかった設定ファイルが使用される', async () => {
+    const { existsSync } = await import('node:fs');
+    const { createJiti } = await import('jiti');
+    const { consola } = await import('consola');
+
+    // .tsファイルが存在する
+    (existsSync as any).mockReturnValueOnce(true);
+
+    const importMock = vi.fn(() =>
+      Promise.resolve({ outputFile: 'custom.ts' }),
+    );
+    (createJiti as any).mockReturnValue({ import: importMock });
+
+    const config = await loadConfig('/project');
+
+    expect(config).toEqual({ outputFile: 'custom.ts' });
+    expect(consola.success).toHaveBeenCalledWith(
+      'Loaded configuration from gasnuki.config.ts',
+    );
+  });
+
+  it('設定ファイルのロードエラーでconsola.errorが呼ばれる', async () => {
+    const { existsSync } = await import('node:fs');
+    const { createJiti } = await import('jiti');
+    const { consola } = await import('consola');
+
+    (existsSync as any).mockReturnValueOnce(true);
+    const importMock = vi.fn(() => {
+      throw new Error('Config load failed');
+    });
+    (createJiti as any).mockReturnValue({ import: importMock });
+
+    const config = await loadConfig('/project');
+
+    expect(config).toEqual({});
+    expect(consola.error).toHaveBeenCalledWith(
+      'Error loading gasnuki.config.ts:',
+      expect.any(Error),
+    );
+  });
+
+  it('jitiが正しいオプションで作成される', async () => {
+    const { existsSync } = await import('node:fs');
+    const { createJiti } = await import('jiti');
+
+    (existsSync as any).mockReturnValueOnce(true);
+    const importMock = vi.fn(() => Promise.resolve({}));
+    (createJiti as any).mockReturnValue({ import: importMock });
+
+    await loadConfig('/project');
+
+    expect(createJiti).toHaveBeenCalledWith('/project', {
+      fsCache: false,
+      moduleCache: false,
+      interopDefault: true,
+    });
+  });
+
+  it('jiti.importが正しいオプションで呼ばれる', async () => {
+    const { existsSync } = await import('node:fs');
+    const { createJiti } = await import('jiti');
+    const path = await import('node:path');
+
+    (existsSync as any).mockReturnValueOnce(true);
+    const importMock = vi.fn(() => Promise.resolve({}));
+    (createJiti as any).mockReturnValue({ import: importMock });
+
+    await loadConfig('/project');
+
+    const expectedPath = path.resolve('/project', 'gasnuki.config.ts');
+    expect(importMock).toHaveBeenCalledWith(expectedPath, {
+      default: true,
+    });
+  });
+
+  it('複雑な設定オブジェクトが正しくロードされる', async () => {
+    const { existsSync } = await import('node:fs');
+    const { createJiti } = await import('jiti');
+
+    const complexConfig = {
+      srcDir: 'server',
+      outDir: 'types',
+      outputFile: 'appsscript.ts',
+    };
+
+    (existsSync as any).mockReturnValueOnce(true);
+    const importMock = vi.fn(() => Promise.resolve(complexConfig));
+    (createJiti as any).mockReturnValue({ import: importMock });
+
+    const config = await loadConfig('/project');
+
+    expect(config).toEqual(complexConfig);
+  });
+
+  it('設定ファイルが見つからない場合にconsolaが呼ばれない', async () => {
+    const { existsSync } = await import('node:fs');
+    const { consola } = await import('consola');
+
+    (existsSync as any).mockReturnValue(false);
+
+    await loadConfig('/project');
+
+    expect(consola.success).not.toHaveBeenCalled();
+    expect(consola.error).not.toHaveBeenCalled();
   });
 });

--- a/tests/modules/generate.test.ts
+++ b/tests/modules/generate.test.ts
@@ -178,4 +178,260 @@ describe('generateAppsScriptTypes', () => {
       'processLocal(param: LocalType): LocalType;',
     );
   });
+
+  it('出力ディレクトリが存在しない場合に作成されること', async () => {
+    const { existsSync, mkdirSync } = await import('node:fs');
+    const { consola } = await import('consola');
+
+    // 出力ディレクトリが存在しないと仮定
+    (existsSync as Mock).mockReturnValue(false);
+
+    const project = new Project({ useInMemoryFileSystem: true });
+    project.createSourceFile(
+      '/project/src/test.ts',
+      'export function test() {}',
+    );
+    (Project as Mock).mockReturnValue(project);
+
+    await generateAppsScriptTypes(opts);
+
+    expect(mkdirSync).toHaveBeenCalledWith(expect.stringContaining('types'), {
+      recursive: true,
+    });
+    expect(consola.info).toHaveBeenCalledWith(
+      expect.stringContaining('Created output directory:'),
+    );
+  });
+
+  it('出力ディレクトリが既に存在する場合は作成されないこと', async () => {
+    const { existsSync, mkdirSync } = await import('node:fs');
+
+    // 出力ディレクトリが存在すると仮定
+    (existsSync as Mock).mockReturnValue(true);
+
+    const project = new Project({ useInMemoryFileSystem: true });
+    project.createSourceFile(
+      '/project/src/test2.ts',
+      'export function test() {}',
+    );
+    (Project as Mock).mockReturnValue(project);
+
+    await generateAppsScriptTypes(opts);
+
+    expect(mkdirSync).not.toHaveBeenCalled();
+  });
+
+  it('関数が見つからない場合の出力内容', async () => {
+    const project = new Project({ useInMemoryFileSystem: true });
+    project.createSourceFile(
+      '/project/src/test3.ts',
+      'export interface Test { id: string; }',
+    );
+    (Project as Mock).mockReturnValue(project);
+    const { writeFileSync } = await import('node:fs');
+    const { consola } = await import('consola');
+
+    await generateAppsScriptTypes(opts);
+
+    const writtenContent = (writeFileSync as Mock).mock.calls[0][1];
+
+    expect(writtenContent).toContain('export type ServerScripts = {');
+    expect(consola.info).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Interface 'ServerScript' type definitions written to",
+      ),
+    );
+  });
+
+  it('関数と型の両方が存在する場合の出力内容', async () => {
+    const project = new Project({ useInMemoryFileSystem: true });
+    project.createSourceFile(
+      '/project/src/test4.ts',
+      `export interface Test { id: string; }
+       export function processTest(test: Test): Test { return test; }`,
+    );
+    (Project as Mock).mockReturnValue(project);
+    const { writeFileSync } = await import('node:fs');
+    const { consola } = await import('consola');
+
+    await generateAppsScriptTypes(opts);
+
+    const writtenContent = (writeFileSync as Mock).mock.calls[0][1];
+
+    expect(writtenContent).toContain('export interface Test { id: string; }');
+    expect(writtenContent).toContain('processTest(test: Test): Test;');
+    expect(writtenContent).toContain('export type ServerScripts = {');
+    expect(consola.info).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Interface 'ServerScript' type definitions written to",
+      ),
+    );
+  });
+
+  it('インポート文が正しくソートされること', async () => {
+    const project = new Project({ useInMemoryFileSystem: true });
+    project.createSourceFile(
+      '/project/src/models/user.ts',
+      'export interface User { id: number; }',
+    );
+    project.createSourceFile(
+      '/project/src/models/admin.ts',
+      'export interface Admin { role: string; }',
+    );
+    project.createSourceFile(
+      '/project/src/main6.ts',
+      `import { User } from './models/user';
+       import { Admin } from './models/admin';
+       export function processUser(user: User): User { return user; }
+       export function processAdmin(admin: Admin): Admin { return admin; }`,
+    );
+    (Project as Mock).mockReturnValue(project);
+    const { writeFileSync } = await import('node:fs');
+
+    await generateAppsScriptTypes(opts);
+
+    const writtenContent = (writeFileSync as Mock).mock.calls[0][1];
+
+    // インポート文が正しくソートされていることを確認
+    const importLines = writtenContent
+      .split('\n')
+      .filter((line: string) => line.startsWith('import type'))
+      .map((line: string) => line.trim());
+
+    if (importLines.length >= 2) {
+      expect(importLines[0]).toContain('./models/admin');
+      expect(importLines[1]).toContain('./models/user');
+    }
+  });
+
+  it('複雑な型参照が正しく処理されること', async () => {
+    const project = new Project({ useInMemoryFileSystem: true });
+    project.createSourceFile(
+      '/project/src/types2.ts',
+      `export interface Base { id: string; }
+       export interface Extended extends Base { name: string; }
+       export type ComplexType = Extended & { extra: boolean; }`,
+    );
+    project.createSourceFile(
+      '/project/src/main7.ts',
+      `import { ComplexType } from './types2';
+       export function processComplex(data: ComplexType): ComplexType { return data; }`,
+    );
+    (Project as Mock).mockReturnValue(project);
+    const { writeFileSync } = await import('node:fs');
+
+    await generateAppsScriptTypes(opts);
+
+    const writtenContent = (writeFileSync as Mock).mock.calls[0][1];
+
+    expect(writtenContent).toContain('export interface Base { id: string; }');
+    expect(writtenContent).toContain(
+      'export interface Extended extends Base { name: string; }',
+    );
+    expect(writtenContent).toContain(
+      'export type ComplexType = Extended & { extra: boolean; }',
+    );
+    expect(writtenContent).toContain(
+      'processComplex(data: ComplexType): ComplexType;',
+    );
+  });
+
+  it('配列型とジェネリック型が正しく処理されること', async () => {
+    const project = new Project({ useInMemoryFileSystem: true });
+    project.createSourceFile(
+      '/project/src/types3.ts',
+      `export interface Item { id: number; name: string; }
+       export type ItemArray = Item[];
+       export type OptionalItem = Item | null;`,
+    );
+    project.createSourceFile(
+      '/project/src/main8.ts',
+      `import { ItemArray, OptionalItem } from './types3';
+       export function processItems(items: ItemArray): ItemArray { return items; }
+       export function processOptional(item: OptionalItem): OptionalItem { return item; }`,
+    );
+    (Project as Mock).mockReturnValue(project);
+    const { writeFileSync } = await import('node:fs');
+
+    await generateAppsScriptTypes(opts);
+
+    const writtenContent = (writeFileSync as Mock).mock.calls[0][1];
+
+    expect(writtenContent).toContain(
+      'export interface Item { id: number; name: string; }',
+    );
+    expect(writtenContent).toContain('export type ItemArray = Item[];');
+    expect(writtenContent).toContain('export type OptionalItem = Item | null;');
+    expect(writtenContent).toContain(
+      'processItems(items: ItemArray): ItemArray;',
+    );
+    expect(writtenContent).toContain(
+      'processOptional(item: OptionalItem): OptionalItem;',
+    );
+  });
+
+  it('ネストしたオブジェクト型が正しく処理されること', async () => {
+    const project = new Project({ useInMemoryFileSystem: true });
+    project.createSourceFile(
+      '/project/src/types4.ts',
+      `export interface Address { street: string; city: string; }
+       export interface User { 
+         id: number; 
+         name: string; 
+         address: Address;
+         tags: string[];
+       }`,
+    );
+    project.createSourceFile(
+      '/project/src/main9.ts',
+      `import { User } from './types4';
+       export function processUser(user: User): User { return user; }`,
+    );
+    (Project as Mock).mockReturnValue(project);
+    const { writeFileSync } = await import('node:fs');
+
+    await generateAppsScriptTypes(opts);
+
+    const writtenContent = (writeFileSync as Mock).mock.calls[0][1];
+
+    expect(writtenContent).toContain(
+      'export interface Address { street: string; city: string; }',
+    );
+    expect(writtenContent).toContain('export interface User {');
+    expect(writtenContent).toContain('address: Address;');
+    expect(writtenContent).toContain('tags: string[];');
+    expect(writtenContent).toContain('processUser(user: User): User;');
+  });
+
+  it('Union型とIntersection型が正しく処理されること', async () => {
+    const project = new Project({ useInMemoryFileSystem: true });
+    project.createSourceFile(
+      '/project/src/types5.ts',
+      `export interface A { a: string; }
+       export interface B { b: number; }
+       export type Union = A | B;
+       export type Intersection = A & B;`,
+    );
+    project.createSourceFile(
+      '/project/src/main10.ts',
+      `import { Union, Intersection } from './types5';
+       export function processUnion(data: Union): Union { return data; }
+       export function processIntersection(data: Intersection): Intersection { return data; }`,
+    );
+    (Project as Mock).mockReturnValue(project);
+    const { writeFileSync } = await import('node:fs');
+
+    await generateAppsScriptTypes(opts);
+
+    const writtenContent = (writeFileSync as Mock).mock.calls[0][1];
+
+    expect(writtenContent).toContain('export interface A { a: string; }');
+    expect(writtenContent).toContain('export interface B { b: number; }');
+    expect(writtenContent).toContain('export type Union = A | B;');
+    expect(writtenContent).toContain('export type Intersection = A & B;');
+    expect(writtenContent).toContain('processUnion(data: Union): Union;');
+    expect(writtenContent).toContain(
+      'processIntersection(data: Intersection): Intersection;',
+    );
+  });
 });


### PR DESCRIPTION
…フェース名を修正し、CLIオプションの優先順位に関するテストを追加。設定ファイルのロード処理を改善し、出力ディレクトリの存在確認と作成に関するテストを追加。