### PR TITLE
ci(workflow): pnpm installステップを追加

### DIFF
--- a/.github/workflows/pkgVersion.yml
+++ b/.github/workflows/pkgVersion.yml
@@ -32,6 +32,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
           cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
     
       - name: Check for outdated packages and save result
         id: outdated-check


### PR DESCRIPTION
`pnpm outdated` を実行する前に `pnpm install` を実行するようにワークフローを修正しました。

これにより、依存関係が正しく解決され、outdatedパッケージのチェックが正確に行われるようになります。 また、`actions/setup-node` でのキャッシュエラーの解消も期待されます。