### PR TITLE
feat: support JSON parsing in mockup functions and bump version

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,7 +1,7 @@
 # @ciderjs/gasnuki
 
 [![README-en](https://img.shields.io/badge/English-blue?logo=ReadMe)](./README.md)
-[![Test Coverage](https://img.shields.io/badge/test%20coverage-93.03%25-brightgreen)](https://github.com/luthpg/gasnuki)
+[![Test Coverage](https://img.shields.io/badge/test%20coverage-92.76%25-brightgreen)](https://github.com/luthpg/gasnuki)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![npm version](https://img.shields.io/npm/v/@ciderjs/gasnuki.svg)](https://www.npmjs.com/package/@ciderjs/gasnuki)
 ![NPM Downloads](https://img.shields.io/npm/dw/@ciderjs/gasnuki)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # @ciderjs/gasnuki
 
 [![README-ja](https://img.shields.io/badge/日本語-blue?logo=ReadMe)](./README.ja.md)
-[![Test Coverage](https://img.shields.io/badge/test%20coverage-93.03%25-brightgreen)](https://github.com/luthpg/gasnuki)
+[![Test Coverage](https://img.shields.io/badge/test%20coverage-92.76%25-brightgreen)](https://github.com/luthpg/gasnuki)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![npm version](https://img.shields.io/npm/v/@ciderjs/gasnuki.svg)](https://www.npmjs.com/package/@ciderjs/gasnuki)
 ![NPM Downloads](https://img.shields.io/npm/dw/@ciderjs/gasnuki)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ciderjs/gasnuki",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Type definitions and utilities for Google Apps Script client-side API",
   "main": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/src/promise.ts
+++ b/src/promise.ts
@@ -21,9 +21,7 @@ export type GetPromisedServerScriptsOptions<
   T,
   IsJson extends boolean = boolean,
 > = {
-  mockupFunctions?: IsJson extends true
-    ? PartialScriptTypeWithJson<T>
-    : PartialScriptType<T>;
+  mockupFunctions?: PartialScriptType<T>;
   parseJson?: IsJson;
 };
 
@@ -56,7 +54,24 @@ export function getPromisedServerScripts<
   >(mockupFunctions as any, {
     get(target, method: string) {
       if (!('google' in globalThis) || !google?.script?.run) {
-        return target[method];
+        const mockFunc = target[method];
+        if (!mockFunc) {
+          return undefined;
+        }
+        if (!parseJson) {
+          return mockFunc;
+        }
+        return async (...args: any[]) => {
+          const res = await mockFunc(...args);
+          if (typeof res === 'string') {
+            try {
+              return deserialize(res as any);
+            } catch {
+              return res;
+            }
+          }
+          return res;
+        };
       }
       if (!(method in google.script.run)) {
         throw Error(`Method ${method} not found in AppsScript.`);

--- a/tests/promise.test.ts
+++ b/tests/promise.test.ts
@@ -445,4 +445,44 @@ describe('getPromisedServerScripts', () => {
     const value = await result.jsonMethod();
     expect(value).toBe('{"key":"value"}');
   });
+
+  it('mockupFunctions: parseJson: true の場合、mockupが返すJsonStringが自動的にデシリアライズされる', async () => {
+    // google.script.runが存在しない
+    (globalThis as any).google = undefined;
+
+    const mockupFunctions = {
+      jsonMethod: vi
+        .fn()
+        .mockResolvedValue('{"date":"2023-01-01T00:00:00.000Z"}'),
+    };
+
+    const result = getPromisedServerScripts<{ jsonMethod: () => any }>({
+      mockupFunctions,
+      parseJson: true,
+    });
+
+    const value = await result.jsonMethod();
+    expect(value).toEqual({ date: expect.any(Date) });
+    expect(value.date.toISOString()).toBe('2023-01-01T00:00:00.000Z');
+  });
+
+  it('mockupFunctions: parseJson: true の場合でも、mockupがオブジェクトを返せばそのまま返される（後方互換性）', async () => {
+    // google.script.runが存在しない
+    (globalThis as any).google = undefined;
+
+    const expectedObj = { date: new Date('2023-01-01T00:00:00.000Z') };
+    const mockupFunctions = {
+      // 型定義上はエラーになる可能性があるが、ランタイムでは動作することを確認
+      jsonMethod: vi.fn().mockResolvedValue(expectedObj),
+    };
+
+    const result = getPromisedServerScripts<{ jsonMethod: () => any }>({
+      // @ts-expect-error テストのために型エラーを無視
+      mockupFunctions,
+      parseJson: true,
+    });
+
+    const value = await result.jsonMethod();
+    expect(value).toBe(expectedObj);
+  });
 });


### PR DESCRIPTION
- Updated 'getPromisedServerScripts' to deserialize JSON results from mockup functions when 'parseJson' is true.
- Simplified 'GetPromisedServerScriptsOptions' type for 'mockupFunctions'.
- Added tests for JSON parsing in mockup functions in 'tests/promise.test.ts'.
- Bumped package version to 0.5.1.
- Updated test coverage badges in READMEs.