### PR TITLE
fix: prevent invalid imports for global type definitions

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,7 +1,7 @@
 # @ciderjs/gasnuki
 
 [![README-en](https://img.shields.io/badge/English-blue?logo=ReadMe)](./README.md)
-[![Test Coverage](https://img.shields.io/badge/test%20coverage-89.07%25-green)](https://github.com/luthpg/gasnuki)
+[![Test Coverage](https://img.shields.io/badge/test%20coverage-89.02%25-green)](https://github.com/luthpg/gasnuki)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![npm version](https://img.shields.io/npm/v/@ciderjs/gasnuki.svg)](https://www.npmjs.com/package/@ciderjs/gasnuki)
 ![NPM Downloads](https://img.shields.io/npm/dw/@ciderjs/gasnuki)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # @ciderjs/gasnuki
 
 [![README-ja](https://img.shields.io/badge/日本語-blue?logo=ReadMe)](./README.ja.md)
-[![Test Coverage](https://img.shields.io/badge/test%20coverage-89.07%25-green)](https://github.com/luthpg/gasnuki)
+[![Test Coverage](https://img.shields.io/badge/test%20coverage-89.02%25-green)](https://github.com/luthpg/gasnuki)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![npm version](https://img.shields.io/npm/v/@ciderjs/gasnuki.svg)](https://www.npmjs.com/package/@ciderjs/gasnuki)
 ![NPM Downloads](https://img.shields.io/npm/dw/@ciderjs/gasnuki)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ciderjs/gasnuki",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Type definitions and utilities for Google Apps Script client-side API",
   "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -68,12 +68,12 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.11",
-    "@types/node": "^25.0.6",
-    "@vitest/coverage-v8": "4.0.16",
+    "@types/node": "^25.0.9",
+    "@vitest/coverage-v8": "4.0.17",
     "typescript": "^5.9.3",
     "unbuild": "^3.6.1",
     "vite": "^7.3.1",
-    "vitest": "4.0.16"
+    "vitest": "4.0.17"
   },
   "peerDependencies": {
     "vite": "^7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,11 +28,11 @@ importers:
         specifier: ^2.3.11
         version: 2.3.11
       '@types/node':
-        specifier: ^25.0.6
-        version: 25.0.6
+        specifier: ^25.0.9
+        version: 25.0.9
       '@vitest/coverage-v8':
-        specifier: 4.0.16
-        version: 4.0.16(vitest@4.0.16(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1))
+        specifier: 4.0.17
+        version: 4.0.17(vitest@4.0.17(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -41,10 +41,10 @@ importers:
         version: 3.6.1(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1)
+        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1)
       vitest:
-        specifier: 4.0.16
-        version: 4.0.16(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1)
+        specifier: 4.0.17
+        version: 4.0.17(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1)
 
   playground/react:
     dependencies:
@@ -63,7 +63,7 @@ importers:
         version: 9.31.0
       '@google/clasp':
         specifier: 3.0.6-alpha
-        version: 3.0.6-alpha(@types/node@25.0.6)(typescript@5.8.3)
+        version: 3.0.6-alpha(@types/node@25.0.9)(typescript@5.8.3)
       '@types/google-apps-script':
         specifier: ^1.0.99
         version: 1.0.99
@@ -75,7 +75,7 @@ importers:
         version: 19.1.6(@types/react@19.1.8)
       '@vitejs/plugin-react':
         specifier: ^4.4.1
-        version: 4.7.0(vite@6.3.5(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1))
+        version: 4.7.0(vite@6.3.5(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1))
       cpx:
         specifier: ^1.5.0
         version: 1.5.0
@@ -105,13 +105,13 @@ importers:
         version: 8.38.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3)
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1)
+        version: 6.3.5(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1)
       vite-plugin-google-apps-script:
         specifier: ^0.3.2
-        version: 0.3.2(@types/node@25.0.6)(jiti@2.6.1)
+        version: 0.3.2(@types/node@25.0.9)(jiti@2.6.1)
       vite-plugin-singlefile:
         specifier: ^2.3.0
-        version: 2.3.0(rollup@4.55.1)(vite@6.3.5(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1))
+        version: 2.3.0(rollup@4.55.1)(vite@6.3.5(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1))
 
   playground/react-with-vite-plugin:
     dependencies:
@@ -130,7 +130,7 @@ importers:
         version: 9.31.0
       '@google/clasp':
         specifier: 3.0.6-alpha
-        version: 3.0.6-alpha(@types/node@25.0.6)(typescript@5.8.3)
+        version: 3.0.6-alpha(@types/node@25.0.9)(typescript@5.8.3)
       '@types/google-apps-script':
         specifier: ^1.0.99
         version: 1.0.99
@@ -142,7 +142,7 @@ importers:
         version: 19.1.6(@types/react@19.1.8)
       '@vitejs/plugin-react':
         specifier: ^4.4.1
-        version: 4.7.0(vite@6.3.5(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1))
+        version: 4.7.0(vite@6.3.5(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1))
       cpx:
         specifier: ^1.5.0
         version: 1.5.0
@@ -172,13 +172,13 @@ importers:
         version: 8.38.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3)
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1)
+        version: 6.3.5(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1)
       vite-plugin-google-apps-script:
         specifier: ^0.3.2
-        version: 0.3.2(@types/node@25.0.6)(jiti@2.6.1)
+        version: 0.3.2(@types/node@25.0.9)(jiti@2.6.1)
       vite-plugin-singlefile:
         specifier: ^2.3.0
-        version: 2.3.0(rollup@4.55.1)(vite@6.3.5(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1))
+        version: 2.3.0(rollup@4.55.1)(vite@6.3.5(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1))
 
   playground/vue3:
     dependencies:
@@ -194,7 +194,7 @@ importers:
         version: 1.0.99
       '@vitejs/plugin-vue':
         specifier: ^5.2.3
-        version: 5.2.4(vite@6.3.5(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1))(vue@3.5.17(typescript@5.8.3))
+        version: 5.2.4(vite@6.3.5(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1))(vue@3.5.17(typescript@5.8.3))
       '@vue/tsconfig':
         specifier: ^0.7.0
         version: 0.7.0(typescript@5.8.3)(vue@3.5.17(typescript@5.8.3))
@@ -212,13 +212,13 @@ importers:
         version: 5.8.3
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1)
+        version: 6.3.5(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1)
       vite-plugin-google-apps-script:
         specifier: ^0.3.2
-        version: 0.3.2(@types/node@25.0.6)(jiti@2.6.1)
+        version: 0.3.2(@types/node@25.0.9)(jiti@2.6.1)
       vite-plugin-singlefile:
         specifier: ^2.3.0
-        version: 2.3.0(rollup@4.55.1)(vite@6.3.5(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1))
+        version: 2.3.0(rollup@4.55.1)(vite@6.3.5(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1))
       vue-tsc:
         specifier: ^2.2.8
         version: 2.2.12(typescript@5.8.3)
@@ -231,6 +231,10 @@ packages:
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/code-frame@7.28.6':
+    resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/compat-data@7.28.0':
@@ -292,8 +296,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/parser@7.28.5':
-    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
+  '@babel/parser@7.28.6':
+    resolution: {integrity: sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -321,8 +325,8 @@ packages:
     resolution: {integrity: sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.28.5':
-    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
+  '@babel/types@7.28.6':
+    resolution: {integrity: sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -1696,11 +1700,11 @@ packages:
   '@types/mute-stream@0.0.1':
     resolution: {integrity: sha512-0yQLzYhCqGz7CQPE3iDmYjhb7KMBFOP+tBkyw+/Y2YyDI5wpS7itXXxneN1zSsUwWx3Ji6YiVYrhAnpQGS/vkw==}
 
-  '@types/node@20.19.28':
-    resolution: {integrity: sha512-VyKBr25BuFDzBFCK5sUM6ZXiWfqgCTwTAOK8qzGV/m9FCirXYDlmczJ+d5dXBAQALGCdRRdbteKYfJ84NGEusw==}
+  '@types/node@20.19.30':
+    resolution: {integrity: sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==}
 
-  '@types/node@25.0.6':
-    resolution: {integrity: sha512-NNu0sjyNxpoiW3YuVFfNz7mxSQ+S4X2G28uqg2s+CzoqoQjLPsWSbsFFyztIAqt2vb8kfEAsJNepMGPTxFDx3Q==}
+  '@types/node@25.0.9':
+    resolution: {integrity: sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -1791,20 +1795,20 @@ packages:
       vite: ^5.0.0 || ^6.0.0
       vue: ^3.2.25
 
-  '@vitest/coverage-v8@4.0.16':
-    resolution: {integrity: sha512-2rNdjEIsPRzsdu6/9Eq0AYAzYdpP6Bx9cje9tL3FE5XzXRQF1fNU9pe/1yE8fCrS0HD+fBtt6gLPh6LI57tX7A==}
+  '@vitest/coverage-v8@4.0.17':
+    resolution: {integrity: sha512-/6zU2FLGg0jsd+ePZcwHRy3+WpNTBBhDY56P4JTRqUN/Dp6CvOEa9HrikcQ4KfV2b2kAHUFB4dl1SuocWXSFEw==}
     peerDependencies:
-      '@vitest/browser': 4.0.16
-      vitest: 4.0.16
+      '@vitest/browser': 4.0.17
+      vitest: 4.0.17
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.0.16':
-    resolution: {integrity: sha512-eshqULT2It7McaJkQGLkPjPjNph+uevROGuIMJdG3V+0BSR2w9u6J9Lwu+E8cK5TETlfou8GRijhafIMhXsimA==}
+  '@vitest/expect@4.0.17':
+    resolution: {integrity: sha512-mEoqP3RqhKlbmUmntNDDCJeTDavDR+fVYkSOw8qRwJFaW/0/5zA9zFeTrHqNtcmwh6j26yMmwx2PqUDPzt5ZAQ==}
 
-  '@vitest/mocker@4.0.16':
-    resolution: {integrity: sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==}
+  '@vitest/mocker@4.0.17':
+    resolution: {integrity: sha512-+ZtQhLA3lDh1tI2wxe3yMsGzbp7uuJSWBM1iTIKCbppWTSBN09PUC+L+fyNlQApQoR+Ps8twt2pbSSXg2fQVEQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0-0
@@ -1814,20 +1818,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.0.16':
-    resolution: {integrity: sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==}
+  '@vitest/pretty-format@4.0.17':
+    resolution: {integrity: sha512-Ah3VAYmjcEdHg6+MwFE17qyLqBHZ+ni2ScKCiW2XrlSBV4H3Z7vYfPfz7CWQ33gyu76oc0Ai36+kgLU3rfF4nw==}
 
-  '@vitest/runner@4.0.16':
-    resolution: {integrity: sha512-VWEDm5Wv9xEo80ctjORcTQRJ539EGPB3Pb9ApvVRAY1U/WkHXmmYISqU5E79uCwcW7xYUV38gwZD+RV755fu3Q==}
+  '@vitest/runner@4.0.17':
+    resolution: {integrity: sha512-JmuQyf8aMWoo/LmNFppdpkfRVHJcsgzkbCA+/Bk7VfNH7RE6Ut2qxegeyx2j3ojtJtKIbIGy3h+KxGfYfk28YQ==}
 
-  '@vitest/snapshot@4.0.16':
-    resolution: {integrity: sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==}
+  '@vitest/snapshot@4.0.17':
+    resolution: {integrity: sha512-npPelD7oyL+YQM2gbIYvlavlMVWUfNNGZPcu0aEUQXt7FXTuqhmgiYupPnAanhKvyP6Srs2pIbWo30K0RbDtRQ==}
 
-  '@vitest/spy@4.0.16':
-    resolution: {integrity: sha512-4jIOWjKP0ZUaEmJm00E0cOBLU+5WE0BpeNr3XN6TEF05ltro6NJqHWxXD0kA8/Zc8Nh23AT8WQxwNG+WeROupw==}
+  '@vitest/spy@4.0.17':
+    resolution: {integrity: sha512-I1bQo8QaP6tZlTomQNWKJE6ym4SHf3oLS7ceNjozxxgzavRAgZDc06T7kD8gb9bXKEgcLNt00Z+kZO6KaJ62Ew==}
 
-  '@vitest/utils@4.0.16':
-    resolution: {integrity: sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==}
+  '@vitest/utils@4.0.17':
+    resolution: {integrity: sha512-RG6iy+IzQpa9SB8HAFHJ9Y+pTzI+h8553MrciN9eC6TFBErqrQaTas4vG+MVj8S4uKk8uTT2p0vgZPnTdxd96w==}
 
   '@volar/language-core@2.4.15':
     resolution: {integrity: sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==}
@@ -2010,8 +2014,8 @@ packages:
     resolution: {integrity: sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==}
     engines: {node: '>=0.10.0'}
 
-  baseline-browser-mapping@2.9.14:
-    resolution: {integrity: sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==}
+  baseline-browser-mapping@2.9.15:
+    resolution: {integrity: sha512-kX8h7K2srmDyYnXRIppo4AH/wYgzWVCs+eKr3RusRSQ5PvRYoEFmR/I0PbdTjKFAoKqp5+kbxnNTFO9jOfSVJg==}
     hasBin: true
 
   bignumber.js@9.3.1:
@@ -3063,10 +3067,6 @@ packages:
 
   istanbul-lib-report@3.0.1:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
-    engines: {node: '>=10'}
-
-  istanbul-lib-source-maps@5.0.6:
-    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
     engines: {node: '>=10'}
 
   istanbul-reports@3.2.0:
@@ -4181,8 +4181,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ufo@1.6.2:
-    resolution: {integrity: sha512-heMioaxBcG9+Znsda5Q8sQbWnLJSl98AFDXTO80wELWEzX3hordXsTdxrIfMQoO9IY1MEnoGoPjpoKpMj+Yx0Q==}
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
   unbuild@3.6.1:
     resolution: {integrity: sha512-+U5CdtrdjfWkZhuO4N9l5UhyiccoeMEXIc2Lbs30Haxb+tRwB3VwB8AoZRxlAzORXunenSo+j6lh45jx+xkKgg==}
@@ -4349,18 +4349,18 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.0.16:
-    resolution: {integrity: sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==}
+  vitest@4.0.17:
+    resolution: {integrity: sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.0.16
-      '@vitest/browser-preview': 4.0.16
-      '@vitest/browser-webdriverio': 4.0.16
-      '@vitest/ui': 4.0.16
+      '@vitest/browser-playwright': 4.0.17
+      '@vitest/browser-preview': 4.0.17
+      '@vitest/browser-webdriverio': 4.0.17
+      '@vitest/ui': 4.0.17
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -4467,6 +4467,12 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.28.6':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.28.0': {}
 
   '@babel/core@7.28.0':
@@ -4542,9 +4548,9 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.1
 
-  '@babel/parser@7.28.5':
+  '@babel/parser@7.28.6':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.28.6
 
   '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.0)':
     dependencies:
@@ -4579,7 +4585,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
-  '@babel/types@7.28.5':
+  '@babel/types@7.28.6':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
@@ -4951,7 +4957,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  '@google/clasp@3.0.6-alpha(@types/node@25.0.6)(typescript@5.8.3)':
+  '@google/clasp@3.0.6-alpha(@types/node@25.0.9)(typescript@5.8.3)':
     dependencies:
       '@formatjs/intl': 3.1.6(typescript@5.8.3)
       '@modelcontextprotocol/sdk': 1.17.0
@@ -4967,7 +4973,7 @@ snapshots:
       googleapis: 148.0.0
       googleapis-common: 7.2.0
       inflection: 3.0.2
-      inquirer: 12.8.2(@types/node@25.0.6)
+      inquirer: 12.8.2(@types/node@25.0.9)
       inquirer-autocomplete-standalone: 0.8.1
       loud-rejection: 2.2.0
       micromatch: 4.0.8
@@ -5000,27 +5006,27 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inquirer/checkbox@4.2.0(@types/node@25.0.6)':
+  '@inquirer/checkbox@4.2.0(@types/node@25.0.9)':
     dependencies:
-      '@inquirer/core': 10.1.15(@types/node@25.0.6)
+      '@inquirer/core': 10.1.15(@types/node@25.0.9)
       '@inquirer/figures': 1.0.13
-      '@inquirer/type': 3.0.8(@types/node@25.0.6)
+      '@inquirer/type': 3.0.8(@types/node@25.0.9)
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 25.0.6
+      '@types/node': 25.0.9
 
-  '@inquirer/confirm@5.1.14(@types/node@25.0.6)':
+  '@inquirer/confirm@5.1.14(@types/node@25.0.9)':
     dependencies:
-      '@inquirer/core': 10.1.15(@types/node@25.0.6)
-      '@inquirer/type': 3.0.8(@types/node@25.0.6)
+      '@inquirer/core': 10.1.15(@types/node@25.0.9)
+      '@inquirer/type': 3.0.8(@types/node@25.0.9)
     optionalDependencies:
-      '@types/node': 25.0.6
+      '@types/node': 25.0.9
 
-  '@inquirer/core@10.1.15(@types/node@25.0.6)':
+  '@inquirer/core@10.1.15(@types/node@25.0.9)':
     dependencies:
       '@inquirer/figures': 1.0.13
-      '@inquirer/type': 3.0.8(@types/node@25.0.6)
+      '@inquirer/type': 3.0.8(@types/node@25.0.9)
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
       mute-stream: 2.0.0
@@ -5028,13 +5034,13 @@ snapshots:
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 25.0.6
+      '@types/node': 25.0.9
 
   '@inquirer/core@3.1.2':
     dependencies:
       '@inquirer/type': 1.5.5
       '@types/mute-stream': 0.0.1
-      '@types/node': 20.19.28
+      '@types/node': 20.19.30
       '@types/wrap-ansi': 3.0.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
@@ -5046,95 +5052,95 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
 
-  '@inquirer/editor@4.2.15(@types/node@25.0.6)':
+  '@inquirer/editor@4.2.15(@types/node@25.0.9)':
     dependencies:
-      '@inquirer/core': 10.1.15(@types/node@25.0.6)
-      '@inquirer/type': 3.0.8(@types/node@25.0.6)
+      '@inquirer/core': 10.1.15(@types/node@25.0.9)
+      '@inquirer/type': 3.0.8(@types/node@25.0.9)
       external-editor: 3.1.0
     optionalDependencies:
-      '@types/node': 25.0.6
+      '@types/node': 25.0.9
 
-  '@inquirer/expand@4.0.17(@types/node@25.0.6)':
+  '@inquirer/expand@4.0.17(@types/node@25.0.9)':
     dependencies:
-      '@inquirer/core': 10.1.15(@types/node@25.0.6)
-      '@inquirer/type': 3.0.8(@types/node@25.0.6)
+      '@inquirer/core': 10.1.15(@types/node@25.0.9)
+      '@inquirer/type': 3.0.8(@types/node@25.0.9)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 25.0.6
+      '@types/node': 25.0.9
 
   '@inquirer/figures@1.0.13': {}
 
-  '@inquirer/input@4.2.1(@types/node@25.0.6)':
+  '@inquirer/input@4.2.1(@types/node@25.0.9)':
     dependencies:
-      '@inquirer/core': 10.1.15(@types/node@25.0.6)
-      '@inquirer/type': 3.0.8(@types/node@25.0.6)
+      '@inquirer/core': 10.1.15(@types/node@25.0.9)
+      '@inquirer/type': 3.0.8(@types/node@25.0.9)
     optionalDependencies:
-      '@types/node': 25.0.6
+      '@types/node': 25.0.9
 
-  '@inquirer/number@3.0.17(@types/node@25.0.6)':
+  '@inquirer/number@3.0.17(@types/node@25.0.9)':
     dependencies:
-      '@inquirer/core': 10.1.15(@types/node@25.0.6)
-      '@inquirer/type': 3.0.8(@types/node@25.0.6)
+      '@inquirer/core': 10.1.15(@types/node@25.0.9)
+      '@inquirer/type': 3.0.8(@types/node@25.0.9)
     optionalDependencies:
-      '@types/node': 25.0.6
+      '@types/node': 25.0.9
 
-  '@inquirer/password@4.0.17(@types/node@25.0.6)':
+  '@inquirer/password@4.0.17(@types/node@25.0.9)':
     dependencies:
-      '@inquirer/core': 10.1.15(@types/node@25.0.6)
-      '@inquirer/type': 3.0.8(@types/node@25.0.6)
+      '@inquirer/core': 10.1.15(@types/node@25.0.9)
+      '@inquirer/type': 3.0.8(@types/node@25.0.9)
       ansi-escapes: 4.3.2
     optionalDependencies:
-      '@types/node': 25.0.6
+      '@types/node': 25.0.9
 
-  '@inquirer/prompts@7.7.1(@types/node@25.0.6)':
+  '@inquirer/prompts@7.7.1(@types/node@25.0.9)':
     dependencies:
-      '@inquirer/checkbox': 4.2.0(@types/node@25.0.6)
-      '@inquirer/confirm': 5.1.14(@types/node@25.0.6)
-      '@inquirer/editor': 4.2.15(@types/node@25.0.6)
-      '@inquirer/expand': 4.0.17(@types/node@25.0.6)
-      '@inquirer/input': 4.2.1(@types/node@25.0.6)
-      '@inquirer/number': 3.0.17(@types/node@25.0.6)
-      '@inquirer/password': 4.0.17(@types/node@25.0.6)
-      '@inquirer/rawlist': 4.1.5(@types/node@25.0.6)
-      '@inquirer/search': 3.0.17(@types/node@25.0.6)
-      '@inquirer/select': 4.3.1(@types/node@25.0.6)
+      '@inquirer/checkbox': 4.2.0(@types/node@25.0.9)
+      '@inquirer/confirm': 5.1.14(@types/node@25.0.9)
+      '@inquirer/editor': 4.2.15(@types/node@25.0.9)
+      '@inquirer/expand': 4.0.17(@types/node@25.0.9)
+      '@inquirer/input': 4.2.1(@types/node@25.0.9)
+      '@inquirer/number': 3.0.17(@types/node@25.0.9)
+      '@inquirer/password': 4.0.17(@types/node@25.0.9)
+      '@inquirer/rawlist': 4.1.5(@types/node@25.0.9)
+      '@inquirer/search': 3.0.17(@types/node@25.0.9)
+      '@inquirer/select': 4.3.1(@types/node@25.0.9)
     optionalDependencies:
-      '@types/node': 25.0.6
+      '@types/node': 25.0.9
 
-  '@inquirer/rawlist@4.1.5(@types/node@25.0.6)':
+  '@inquirer/rawlist@4.1.5(@types/node@25.0.9)':
     dependencies:
-      '@inquirer/core': 10.1.15(@types/node@25.0.6)
-      '@inquirer/type': 3.0.8(@types/node@25.0.6)
+      '@inquirer/core': 10.1.15(@types/node@25.0.9)
+      '@inquirer/type': 3.0.8(@types/node@25.0.9)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 25.0.6
+      '@types/node': 25.0.9
 
-  '@inquirer/search@3.0.17(@types/node@25.0.6)':
+  '@inquirer/search@3.0.17(@types/node@25.0.9)':
     dependencies:
-      '@inquirer/core': 10.1.15(@types/node@25.0.6)
+      '@inquirer/core': 10.1.15(@types/node@25.0.9)
       '@inquirer/figures': 1.0.13
-      '@inquirer/type': 3.0.8(@types/node@25.0.6)
+      '@inquirer/type': 3.0.8(@types/node@25.0.9)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 25.0.6
+      '@types/node': 25.0.9
 
-  '@inquirer/select@4.3.1(@types/node@25.0.6)':
+  '@inquirer/select@4.3.1(@types/node@25.0.9)':
     dependencies:
-      '@inquirer/core': 10.1.15(@types/node@25.0.6)
+      '@inquirer/core': 10.1.15(@types/node@25.0.9)
       '@inquirer/figures': 1.0.13
-      '@inquirer/type': 3.0.8(@types/node@25.0.6)
+      '@inquirer/type': 3.0.8(@types/node@25.0.9)
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 25.0.6
+      '@types/node': 25.0.9
 
   '@inquirer/type@1.5.5':
     dependencies:
       mute-stream: 1.0.0
 
-  '@inquirer/type@3.0.8(@types/node@25.0.6)':
+  '@inquirer/type@3.0.8(@types/node@25.0.9)':
     optionalDependencies:
-      '@types/node': 25.0.6
+      '@types/node': 25.0.9
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -5594,13 +5600,13 @@ snapshots:
 
   '@types/mute-stream@0.0.1':
     dependencies:
-      '@types/node': 20.19.28
+      '@types/node': 20.19.30
 
-  '@types/node@20.19.28':
+  '@types/node@20.19.30':
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@25.0.6':
+  '@types/node@25.0.9':
     dependencies:
       undici-types: 7.16.0
 
@@ -5711,7 +5717,7 @@ snapshots:
       '@typescript-eslint/types': 8.38.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react@4.7.0(vite@6.3.5(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1))':
+  '@vitejs/plugin-react@4.7.0(vite@6.3.5(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.0)
@@ -5719,69 +5725,66 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.3.5(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1)
+      vite: 6.3.5(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.2.4(vite@6.3.5(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1))(vue@3.5.17(typescript@5.8.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@6.3.5(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1))(vue@3.5.17(typescript@5.8.3))':
     dependencies:
-      vite: 6.3.5(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1)
+      vite: 6.3.5(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1)
       vue: 3.5.17(typescript@5.8.3)
 
-  '@vitest/coverage-v8@4.0.16(vitest@4.0.16(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1))':
+  '@vitest/coverage-v8@4.0.17(vitest@4.0.17(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.0.16
+      '@vitest/utils': 4.0.17
       ast-v8-to-istanbul: 0.3.10
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.2.0
       magicast: 0.5.1
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.16(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1)
-    transitivePeerDependencies:
-      - supports-color
+      vitest: 4.0.17(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1)
 
-  '@vitest/expect@4.0.16':
+  '@vitest/expect@4.0.17':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.0.16
-      '@vitest/utils': 4.0.16
+      '@vitest/spy': 4.0.17
+      '@vitest/utils': 4.0.17
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.16(vite@7.3.1(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1))':
+  '@vitest/mocker@4.0.17(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1))':
     dependencies:
-      '@vitest/spy': 4.0.16
+      '@vitest/spy': 4.0.17
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1)
+      vite: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1)
 
-  '@vitest/pretty-format@4.0.16':
+  '@vitest/pretty-format@4.0.17':
     dependencies:
       tinyrainbow: 3.0.3
 
-  '@vitest/runner@4.0.16':
+  '@vitest/runner@4.0.17':
     dependencies:
-      '@vitest/utils': 4.0.16
+      '@vitest/utils': 4.0.17
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.0.16':
+  '@vitest/snapshot@4.0.17':
     dependencies:
-      '@vitest/pretty-format': 4.0.16
+      '@vitest/pretty-format': 4.0.17
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.0.16': {}
+  '@vitest/spy@4.0.17': {}
 
-  '@vitest/utils@4.0.16':
+  '@vitest/utils@4.0.17':
     dependencies:
-      '@vitest/pretty-format': 4.0.16
+      '@vitest/pretty-format': 4.0.17
       tinyrainbow: 3.0.3
 
   '@volar/language-core@2.4.15':
@@ -5798,7 +5801,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.17':
     dependencies:
-      '@babel/parser': 7.28.0
+      '@babel/parser': 7.28.6
       '@vue/shared': 3.5.17
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -5990,7 +5993,7 @@ snapshots:
       mixin-deep: 1.3.2
       pascalcase: 0.1.1
 
-  baseline-browser-mapping@2.9.14: {}
+  baseline-browser-mapping@2.9.15: {}
 
   bignumber.js@9.3.1: {}
 
@@ -6060,7 +6063,7 @@ snapshots:
 
   browserslist@4.28.1:
     dependencies:
-      baseline-browser-mapping: 2.9.14
+      baseline-browser-mapping: 2.9.15
       caniuse-lite: 1.0.30001764
       electron-to-chromium: 1.5.267
       node-releases: 2.0.27
@@ -7053,17 +7056,17 @@ snapshots:
       figures: 5.0.0
       picocolors: 1.1.1
 
-  inquirer@12.8.2(@types/node@25.0.6):
+  inquirer@12.8.2(@types/node@25.0.9):
     dependencies:
-      '@inquirer/core': 10.1.15(@types/node@25.0.6)
-      '@inquirer/prompts': 7.7.1(@types/node@25.0.6)
-      '@inquirer/type': 3.0.8(@types/node@25.0.6)
+      '@inquirer/core': 10.1.15(@types/node@25.0.9)
+      '@inquirer/prompts': 7.7.1(@types/node@25.0.9)
+      '@inquirer/type': 3.0.8(@types/node@25.0.9)
       ansi-escapes: 4.3.2
       mute-stream: 2.0.0
       run-async: 4.0.5
       rxjs: 7.8.2
     optionalDependencies:
-      '@types/node': 25.0.6
+      '@types/node': 25.0.9
 
   intl-messageformat@10.7.16:
     dependencies:
@@ -7196,14 +7199,6 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@5.0.6:
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3
-      istanbul-lib-coverage: 3.2.2
-    transitivePeerDependencies:
-      - supports-color
-
   istanbul-reports@3.2.0:
     dependencies:
       html-escaper: 2.0.2
@@ -7305,8 +7300,8 @@ snapshots:
 
   magicast@0.5.1:
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.28.6
+      '@babel/types': 7.28.6
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
@@ -7427,7 +7422,7 @@ snapshots:
       acorn: 8.15.0
       pathe: 2.0.3
       pkg-types: 1.3.1
-      ufo: 1.6.2
+      ufo: 1.6.3
 
   ms@2.0.0: {}
 
@@ -7586,7 +7581,7 @@ snapshots:
 
   parse-json@8.3.0:
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.28.6
       index-to-position: 1.1.0
       type-fest: 4.41.0
 
@@ -7974,7 +7969,7 @@ snapshots:
       rollup: 4.55.1
       typescript: 5.9.3
     optionalDependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.28.6
 
   rollup@4.45.1:
     dependencies:
@@ -8408,7 +8403,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  ufo@1.6.2: {}
+  ufo@1.6.3: {}
 
   unbuild@3.6.1(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3)):
     dependencies:
@@ -8505,11 +8500,11 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-plugin-google-apps-script@0.3.2(@types/node@25.0.6)(jiti@2.6.1):
+  vite-plugin-google-apps-script@0.3.2(@types/node@25.0.9)(jiti@2.6.1):
     dependencies:
       rollup: 4.45.1
       terser: 5.43.1
-      vite: 7.3.1(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1)
+      vite: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -8522,13 +8517,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-singlefile@2.3.0(rollup@4.55.1)(vite@6.3.5(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1)):
+  vite-plugin-singlefile@2.3.0(rollup@4.55.1)(vite@6.3.5(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1)):
     dependencies:
       micromatch: 4.0.8
       rollup: 4.55.1
-      vite: 6.3.5(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1)
+      vite: 6.3.5(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1)
 
-  vite@6.3.5(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1):
+  vite@6.3.5(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1):
     dependencies:
       esbuild: 0.25.10
       fdir: 6.5.0(picomatch@4.0.3)
@@ -8537,12 +8532,12 @@ snapshots:
       rollup: 4.51.0
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 25.0.6
+      '@types/node': 25.0.9
       fsevents: 2.3.3
       jiti: 2.6.1
       terser: 5.43.1
 
-  vite@7.3.1(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1):
+  vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -8551,20 +8546,20 @@ snapshots:
       rollup: 4.55.1
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 25.0.6
+      '@types/node': 25.0.9
       fsevents: 2.3.3
       jiti: 2.6.1
       terser: 5.43.1
 
-  vitest@4.0.16(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1):
+  vitest@4.0.17(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1):
     dependencies:
-      '@vitest/expect': 4.0.16
-      '@vitest/mocker': 4.0.16(vite@7.3.1(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1))
-      '@vitest/pretty-format': 4.0.16
-      '@vitest/runner': 4.0.16
-      '@vitest/snapshot': 4.0.16
-      '@vitest/spy': 4.0.16
-      '@vitest/utils': 4.0.16
+      '@vitest/expect': 4.0.17
+      '@vitest/mocker': 4.0.17(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1))
+      '@vitest/pretty-format': 4.0.17
+      '@vitest/runner': 4.0.17
+      '@vitest/snapshot': 4.0.17
+      '@vitest/spy': 4.0.17
+      '@vitest/utils': 4.0.17
       es-module-lexer: 1.7.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -8576,10 +8571,10 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.0.6)(jiti@2.6.1)(terser@5.43.1)
+      vite: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(terser@5.43.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.0.6
+      '@types/node': 25.0.9
     transitivePeerDependencies:
       - jiti
       - less

--- a/src/modules/generate.ts
+++ b/src/modules/generate.ts
@@ -7,7 +7,7 @@ import {
   type FunctionDeclaration,
   type FunctionExpression,
   type InterfaceDeclaration,
-  type Node,
+  Node,
   Project,
   SymbolFlags,
   SyntaxKind,
@@ -771,6 +771,26 @@ export const generateAppsScriptTypes = async ({
         if (!functionSignatureSymbols.has(symbol)) {
           continue;
         }
+
+        // Check for global declaration file (no top-level import/export)
+        // If it is a global file, we should not generate an import statement
+        const hasExportModifier = sourceFile.getStatements().some((stmt) => {
+          if (Node.isExportable(stmt)) {
+            return stmt.isExported();
+          }
+          return false;
+        });
+
+        const isGlobal =
+          sourceFile.getImportDeclarations().length === 0 &&
+          sourceFile.getExportDeclarations().length === 0 &&
+          sourceFile.getExportAssignments().length === 0 &&
+          !hasExportModifier;
+
+        if (isGlobal) {
+          continue;
+        }
+
         const packageName = resolveNodeModuleSpecifier_(sourceFilePath);
         if (packageName) {
           processedSymbols.add(symbolName);

--- a/tests/modules/generate.test.ts
+++ b/tests/modules/generate.test.ts
@@ -1045,4 +1045,47 @@ export function getUserId(id: UserId): UserId {
 
     expect(writeFileSync).toHaveBeenCalledTimes(1);
   });
+
+  it('@typesパッケージに含まれるグローバルな型定義（exportされていない）をインポートしないこと', async () => {
+    const project = new Project({
+      useInMemoryFileSystem: true,
+      compilerOptions: {
+        types: [],
+      },
+    });
+
+    // @types/google-apps-script のようなグローバル型定義をシミュレート
+    // 特徴: top-level exportを持たない
+    project.createSourceFile(
+      '/node_modules/@types/google-apps-script/index.d.ts',
+      `declare namespace SpreadsheetApp {
+        export interface Sheet {
+          getName(): string;
+        }
+      }
+      declare var SpreadsheetApp: {
+        getActiveSpreadsheet(): any;
+      };`,
+    );
+
+    // srcDir内でグローバル型を使用
+    project.createSourceFile(
+      '/src/gas-script.ts',
+      `export function getSheet(): SpreadsheetApp.Sheet {
+         return SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
+      }`,
+    );
+
+    const { writeFileSync } = await import('node:fs');
+
+    await generateAppsScriptTypes({ ...opts, projectInstance: project });
+
+    const writtenContent = (writeFileSync as Mock).mock.calls[0][1];
+
+    // 1. google-apps-script からのインポートが生成されないことを確認
+    expect(writtenContent).not.toContain("from 'google-apps-script'");
+
+    // 2. SpreadsheetApp.Sheet がそのまま使われているか
+    expect(writtenContent).toContain('getSheet(): SpreadsheetApp.Sheet;');
+  });
 });


### PR DESCRIPTION
- Added check in 'generateAppsScriptTypes' to skip import generation for files without top-level exports (global scripts).

- Updated 'package.json' version to 0.5.3.

- Updated dependencies.